### PR TITLE
개발 데이터 서버 기동 시 insert 처리

### DIFF
--- a/database/init/plan.sql
+++ b/database/init/plan.sql
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS `plan`;
+
+create table `plan` (
+    `id` bigint not null auto_increment,
+    `content` varchar(255),
+    created_at datetime(6),
+    created_by varchar(255),
+    hashtag varchar(255),
+    modified_at datetime(6),
+    modified_by varchar(255),
+    title varchar(255),
+    primary key (id)
+) engine=InnoDB;
+
+LOCK TABLES `plan` WRITE;
+
+insert into plan (content, created_at, created_by, hashtag, modified_at, modified_by, title) values
+('테스트', '2022-03-01 00:00:00', 'cw', 'test', '2022-03-01 00:00:00', 'cw', 'title'),
+('테스트22', '2022-03-01 00:00:00', 'cw', 'test', '2022-03-01 00:00:00', 'cw', 'title');
+
+UNLOCK TABLES;

--- a/database/init/planComment.sql
+++ b/database/init/planComment.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS `plan_comment`;
+
+create table `plan_comment` (
+  `id` bigint not null auto_increment,
+  `content` varchar(255),
+  `created_at` datetime(6),
+  `created_by` varchar(255),
+  `modified_at` datetime(6),
+  `modified_by` varchar(255),
+  `plan_id` bigint,
+  primary key (id)
+) engine=InnoDB;
+
+LOCK TABLES `plan_comment` WRITE;
+
+UNLOCK TABLES;

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -19,5 +19,6 @@ services:
       - MARIADB_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
     volumes:
       - ./database/config:/etc/mysql/conf.d
+      - ./database/init:/docker-entrypoint-initdb.d
     ports:
       - "3306:3306"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ spring:
     port: 6379
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
 
 ---


### PR DESCRIPTION
- Docker compose에 init 폴더에 CREATE, INSERT 문 추가
- init 폴더에서 CREATE 처리하므로  application.yaml의 ddl-auto를 create에서 validate로 변경

This closes #17 